### PR TITLE
preliminary support for instagram galleries

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,18 +12,51 @@ const markdownItFootnote = require("markdown-it-footnote")
 const packageVersion = require("./package.json").version;
 const pluginTOC = require('eleventy-plugin-toc');
 const embeds = require("eleventy-plugin-embed-everything");
+const instamarkup =  function(url) {
+  const pattern = /(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com)\/(?:p\/)?([0-9a-zA-Z-_]{11})(?:\S*)(?=(\s*))\4(?:<\/a>)?(?=(\s*))\5/;
+  const match = pattern.exec(url)
+  const id = match ? match[3] : null
+  let out = ''
+  if (id) {
+    out = '<blockquote ';
+    // class MUST include "instagram-media" because Instagram's script uses it for DOM parsing
+    out += `class="jade-gallery instagram-media"`;
+    out += ` data-instgrm-permalink="https://www.instagram.com/p/${id}">`;
+    out += '</blockquote>';
+  } else {
+    out = `<blockquote class="jade-gallery instagram-media">media not found</blockquote>`;
+  }
+  return out;
+};
 module.exports = function (eleventyConfig) {
+  let markdownLibrary = markdownIt({
+    html: true,
+  }).use(markdownItAnchor, {
+    permalink: markdownItAnchor.permalink.ariaHidden({
+      class: "tdbc-anchor",
+      space: false,
+      symbol: "🔗",
+    }),
+    level: [1, 2, 3],
+    slugify: (str) =>
+    slugify(str, {
+      lower: true,
+      strict: true,
+      remove: /["]/g,
+    }),
+  }).use(markdownItFootnote);
+  eleventyConfig.setLibrary("md", markdownLibrary);
   eleventyConfig.addPlugin(socialImages);
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addPlugin(embeds);
   eleventyConfig.addPlugin(pluginRss);
   eleventyConfig.addPlugin(pluginTOC, {
-  tags: ['h2', 'h3', 'h4'], // which heading tags are selected headings must each have an ID attribute
-  wrapper: 'nav',           // element to put around the root `ol`/`ul`
-  wrapperClass: 'toc',      // class for the element around the root `ol`/`ul`
-  ul: false,                // if to use `ul` instead of `ol`
-  flat: false,              // if subheadings should appear as child of parent or as a sibling
-})
+    tags: ['h2', 'h3', 'h4'], // which heading tags are selected headings must each have an ID attribute
+    wrapper: 'nav',           // element to put around the root `ol`/`ul`
+    wrapperClass: 'toc',      // class for the element around the root `ol`/`ul`
+    ul: false,                // if to use `ul` instead of `ol`
+    flat: false,              // if subheadings should appear as child of parent or as a sibling
+  })
   eleventyConfig.addWatchTarget("./src/sass/");
 
   eleventyConfig.addPassthroughCopy("./src/css");
@@ -46,42 +79,23 @@ module.exports = function (eleventyConfig) {
     });
   });
 
-  eleventyConfig.addFilter("instamarkup", function(url, options, index) {
-    const pattern = /(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com)\/(?:p\/)?([0-9a-zA-Z-_]{11})(?:\S*)(?=(\s*))\4(?:<\/a>)?(?=(\s*))\5/;
-    const match = pattern.exec(url)
-    const id = match ? match[3] : null
-    let out = ''
-    if (id) {
-      out = '<blockquote ';
-      // class MUST include "instagram-media" because Instagram's script uses it for DOM parsing
-      out += `class="jade-gallery instagram-media"`;
-      out += ` data-instgrm-permalink="https://www.instagram.com/p/${id}">`;
-      out += '</blockquote>';
-    } else {
-      out = `<blockquote class="jade-gallery instagram-media">media not found</blockquote>`;
-    }
-    return out;
+  eleventyConfig.addFilter("instamarkup", instamarkup);
 
+  eleventyConfig.addPairedShortcode("instagallery", function(content,links) {
+    let instaEmbeds = links.map((l) => instamarkup(l));
+    return `<article class="gallery">
+<section class="items">
+${instaEmbeds.join('')}
+</section>
+<section class="text">
+${markdownLibrary.render(content)}
+</section>
+</article>`
+  })
+  
   /* Markdown Overrides */
-  let markdownLibrary = markdownIt({
-    html: true,
-  }).use(markdownItAnchor, {
-    permalink: markdownItAnchor.permalink.ariaHidden({
-      class: "tdbc-anchor",
-      space: false,
-      symbol: "🔗",
-    }),
-    level: [1, 2, 3],
-    slugify: (str) =>
-      slugify(str, {
-        lower: true,
-        strict: true,
-        remove: /["]/g,
-      }),
-  }).use(markdownItFootnote);
-  eleventyConfig.setLibrary("md", markdownLibrary);
 
-  return {
+return {
     passthroughFileCopy: true,
     pathPrefix: "/hh-project-11ty-starter-kit",
     dir: {
@@ -90,4 +104,4 @@ module.exports = function (eleventyConfig) {
       layouts: "_layouts",
     },
   };
-};
+}

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -46,6 +46,22 @@ module.exports = function (eleventyConfig) {
     });
   });
 
+  eleventyConfig.addFilter("instamarkup", function(url, options, index) {
+    const pattern = /(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com)\/(?:p\/)?([0-9a-zA-Z-_]{11})(?:\S*)(?=(\s*))\4(?:<\/a>)?(?=(\s*))\5/;
+    const match = pattern.exec(url)
+    const id = match ? match[3] : null
+    let out = ''
+    if (id) {
+      out = '<blockquote ';
+      // class MUST include "instagram-media" because Instagram's script uses it for DOM parsing
+      out += `class="jade-gallery instagram-media"`;
+      out += ` data-instgrm-permalink="https://www.instagram.com/p/${id}">`;
+      out += '</blockquote>';
+    } else {
+      out = `<blockquote class="jade-gallery instagram-media">media not found</blockquote>`;
+    }
+    return out;
+
   /* Markdown Overrides */
   let markdownLibrary = markdownIt({
     html: true,

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -753,7 +753,7 @@ pre[class*=language-] {
   transition: 180ms opacity ease-in-out;
   opacity: 0.3;
   font-size: 0.6em;
-  float: left0.6rem
+  float: left;
   margin-left: -2rem;
   vertical-align: bottom;
   text-decoration: none;
@@ -903,4 +903,33 @@ a.tdbc-ink--dark {
 
 .tdbc-mb-none {
   margin-bottom: 0;
+}
+
+.tdbc-container.gallery-page {
+  width: 100vw;
+  max-width: unset;
+  margin: 20px;
+}
+.tdbc-container.gallery-page article.gallery {
+  display: grid;
+  grid-template-columns: minmax(350px, 2fr) minmax(350px, 1fr);
+  max-width: 100%;
+}
+.tdbc-container.gallery-page article.gallery section.items {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(326px, 1fr));
+}
+
+@media screen and (max-width: 600px) {
+  .tdbc-container.gallery-page article.gallery {
+    margin-left: auto;
+    margin-right: auto;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    grid-auto-rows: minmax(100px, auto);
+  }
+  .tdbc-container.gallery-page article.gallery section.items {
+    margin-left: auto;
+    margin-right: auto;
+    grid-template-columns: repeat(auto-fill, minmax(326px, 1fr));
+  }
 }

--- a/src/_layouts/gallery-section.njk
+++ b/src/_layouts/gallery-section.njk
@@ -1,0 +1,18 @@
+---
+layout: base.njk
+---
+{% include 'sitenav.njk' %}
+{% include 'header.njk' %}
+
+<main class="tdbc-container gallery-page">
+    <article class="gallery">
+      <section class="items">
+        {% for link in instalinks %}
+          {% if loop.last %}<script async defer src="https://www.instagram.com/embed.js"></script>{% endif %}
+          {{link | instamarkup | safe }}
+          {% endfor %}
+      </section>
+      <section class="text">
+        {{ content | safe }}
+      </section>
+    </article>

--- a/src/pages/Proposal.md
+++ b/src/pages/Proposal.md
@@ -1,6 +1,8 @@
 ---
 title: "Proposal Test page Assignment"
 description: 'This page will disucss the proposed research projects topic description, audience, and structure (outline).'
+bodyClass: "gallery-page"
+instalinks: ["https://www.instagram.com/p/B6scc4ejFzJ/", "https://www.instagram.com/p/CLUBQZknOVc/","https://www.instagram.com/p/CXOqKRFrQMF/", "https://www.instagram.com/p/B6vr2ZQjYJq/","https://www.instagram.com/p/BYvEqoUAqBc/?hl=en","https://www.instagram.com/p/B8tjuYzBUZL/"]
 ---
 
 ## Topic Description 
@@ -15,12 +17,14 @@ The intended audience for this project is Queer youth who are interested in fash
  - The second sub-page will house images and external digital media such as Instagram posts journal and magazine entries. This page will also be full of links to the different fashion houses mentioned in the first sub-page.
  - The Third sub-page will again be a writing heavy page about Queer communities and right in Soviet Russia 
 
+{% instagallery instalinks %}
 ### Contemporary Fashion, Art and Activism: Uniting a Community Across Lines 
 Although Queerness itself, such as sexuality, has not been criminalized since 1993 in Russia and 1991 in Ukraine, homosexuality, Queerness, and queer culture have largely disapproved, ostracized, policed and punished by the Russian and Ukrainian communities. 
 
 Within Russian same-sex couples and families are not privy to the same social services, legal rights and protections as heterosexual couples. For example, the state does not recognize marriage between same-sex couples, nor are LGBTQ individuals protected against discrimination and hate crimes. Additionally, traditional forms of protest for Queer Rights such as organized public protest, government criticism, blockades, and marches most affiliated with the New York Gay Rights movement are not legal nor transposable within the Russian state or context. Since 2014, protests, freedom of assembly without government officials' expressed approval have been criminalized and punishable in Russia. 
 
 Additionally, in 2013 Russia passed a "gay propaganda" law that acts as a political arm to suppress gay rights, education, and community online and physically. Members of parliament argue that the objective of the law is to "protect children" from finding information unnatural and immoral people and simultaneously champion "tradtional" family values and structures. 
+{% endinstagallery %}
 
 https://www.instagram.com/p/B6scc4ejFzJ/
 

--- a/src/sass/_gallery.scss
+++ b/src/sass/_gallery.scss
@@ -1,0 +1,35 @@
+body.gallery-page .tdbc-container, .trbc-container.gallery-page {
+    width: 100vw;
+    max-width: 160ch;
+    margin: 20px;
+    article.tdbc-mx-auto, article.gallery {
+        max-width: 120ch;       
+    }
+}
+
+article.gallery {
+    display: grid;
+    grid-template-columns: minmax(350px, 2fr) minmax(350px, 1fr);
+    max-width: 100%;
+    section.items {
+        display: grid;
+        grid-template-columns: repeat( auto-fill, minmax(326px, 1fr) );
+    }
+}
+
+@media screen and (max-width: 600px) {
+    
+    .tdbc-container.gallery-page article.gallery {
+        margin-left: auto;
+        margin-right: auto;
+        
+        grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+        grid-auto-rows: minmax(100px, auto);
+        section.items {
+            margin-left: auto;
+            margin-right: auto;
+            grid-template-columns: repeat( auto-fill, minmax(326px, 1fr) );
+        }
+
+    }
+}

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -7,3 +7,4 @@
 @use "card";
 @use "prism";
 @use "utilities";
+@use "gallery";

--- a/src/socialmedia/example.md
+++ b/src/socialmedia/example.md
@@ -1,7 +1,8 @@
 ---
 title: "Queer Fashion Before Ukraine"
-instalinks: ["https://www.instagram.com/p/B6scc4ejFzJ/", "https://www.instagram.com/p/CLUBQZknOVc/", "https://www.instagram.com/p/CXOqKRFrQMF/", "https://www.instagram.com/p/B6vr2ZQjYJq/", "https://www.instagram.com/p/BYvEqoUAqBc/?hl=en", "https://www.instagram.com/p/B8tjuYzBUZL/"]
+instalinks: ["https://www.instagram.com/p/B6scc4ejFzJ/", "https://www.instagram.com/p/CLUBQZknOVc/","https://www.instagram.com/p/CXOqKRFrQMF/" "https://www.instagram.com/p/B6vr2ZQjYJq/","https://www.instagram.com/p/BYvEqoUAqBc/?hl=en","https://www.instagram.com/p/B8tjuYzBUZL/"]
 tags: ["fashion"]
+layout: "gallery-section.njk"
 ---
 
 Now I'm writing some markdown to describe and analyze the image.  whatever I write here is going to be displayed next to the image.

--- a/src/socialmedia/example.md
+++ b/src/socialmedia/example.md
@@ -1,6 +1,6 @@
 ---
 title: "Queer Fashion Before Ukraine"
-instalinks: ["https://www.instagram.com/p/B6scc4ejFzJ/", "https://www.instagram.com/p/CLUBQZknOVc/","https://www.instagram.com/p/CXOqKRFrQMF/" "https://www.instagram.com/p/B6vr2ZQjYJq/","https://www.instagram.com/p/BYvEqoUAqBc/?hl=en","https://www.instagram.com/p/B8tjuYzBUZL/"]
+instalinks: ["https://www.instagram.com/p/B6scc4ejFzJ/", "https://www.instagram.com/p/CLUBQZknOVc/","https://www.instagram.com/p/CXOqKRFrQMF/", "https://www.instagram.com/p/B6vr2ZQjYJq/","https://www.instagram.com/p/BYvEqoUAqBc/?hl=en","https://www.instagram.com/p/B8tjuYzBUZL/"]
 tags: ["fashion"]
 layout: "gallery-section.njk"
 ---


### PR DESCRIPTION
- add a filter to manually produce instagram embeds from urls (copied
from eleventy-plugin-embed-instagram)
- add a gallery-section layout (will need to be modified and moved to
`_includes` in order to use it in a regular post)
- update `socialmedia/example.md` to use new template
- add new scss to handle display/responsiveness.